### PR TITLE
Use apt_java_package variable in debconf task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
   when: install_java
 
 - name: Accept Oracle license prior JDK installation
-  debconf: name='oracle-java7-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+  debconf: name={{apt_java_package}} question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
   when: install_java
 
 - name: Install Java


### PR DESCRIPTION
Package name 'oracle-java7-installer' was hard-coded.