### PR TITLE
Supply Ubuntu series codename for Ubuntu PPA on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Ansible Role](https://img.shields.io/ansible/role/9594.svg?maxAge=2592000)](https://galaxy.ansible.com/jpnewman/java/)
 [![Build Status](https://travis-ci.org/jpnewman/ansible-role-java.svg?branch=master)](https://travis-ci.org/jpnewman/ansible-role-java)
 
-This is a Ansible role to installs Java 8
+This is an Ansible role to install Java 8
 
 ## Requirements
 
@@ -17,6 +17,12 @@ Ansible 2.x
 |```apt_java_repo```||ppa:webupd8team/java|
 |```apt_java_package```||oracle-java8-installer|
 |```install_java```||"true"|
+
+Variables specific to Debian:
+
+|Variable|Description|Default|
+|---|---|---|
+|```apt_java_codename```|Supply series codename for Ubuntu PPA|xenial|
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 apt_cache_valid_time: 600
 apt_java_repo: ppa:webupd8team/java
 apt_java_package: oracle-java8-installer
+# apt_java_codename: "{{ ansible_distribution_release }}"
 install_java: "true"
 
 java_security_policies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,22 @@
+- name: Load platform-specific variable file, if present
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}.yml"
+
 - name: Add java repo
   apt_repository:
     repo: "{{ apt_java_repo }}"
     state: present
     update_cache: yes
-  when: install_java
+  when: install_java and apt_java_codename is undefined
+
+- name: Add java repo with explicit codename supplied
+  apt_repository:
+    repo: "{{ apt_java_repo }}"
+    codename: "{{ apt_java_codename }}"
+    state: present
+    update_cache: yes
+  when: install_java and apt_java_codename is defined
 
 - name: Accept Oracle license prior JDK installation (select)
   debconf: name={{ apt_java_package }} question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+# Supply an Ubuntu series codename for APT on Debian.
+apt_java_codename: "xenial"


### PR DESCRIPTION
The Ubuntu PPA does not have Debian series codenames, so one has to supply one when targeting a Debian box.