### PR TITLE
Supply Ubuntu series codename for Ubuntu PPA on Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Load platform-specific variable file, if present
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files: "{{ ansible_distribution }}.yml"
+      skip: true
+
 - name: Add java repo
   apt_repository:
     repo: "{{ apt_java_repo }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+# Supply an Ubuntu series codename for using the Ubuntu PPA on Debian.
+apt_java_codename: "xenial"


### PR DESCRIPTION
The Ubuntu PPA does not have Debian series codenames, so one has to supply one when targeting a Debian box.