### PR TITLE
Require molecule 1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 
-molecule
+molecule < 2
 python-vagrant
 testinfra


### PR DESCRIPTION
There is a new molecule release v2 which is not compatible with v1.
Make sure we pick the latest stable v1 release.