### PR TITLE
Add support for Debian stretch

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -45,6 +45,7 @@ molecule test --platform=all
 molecule test --platform=trusty64
 molecule test --platform=xenial64
 molecule test --platform=jessie64
+molecule test --platform=stretch64
 ~~~
 
 ### Login
@@ -53,6 +54,7 @@ molecule test --platform=jessie64
 molecule login --host ansible-role-java-trusty64
 molecule login --host ansible-role-java-xenial64
 molecule login --host ansible-role-java-jessie64
+molecule login --host ansible-role-java-stretch64
 ~~~
 
 ## Destroy, All Platforms

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ java_security_policies: []
 codename_apt_codename_map:
   - release_codename: jessie
     use_apt_codename: xenial
+  - release_codename: stretch
+    use_apt_codename: xenial

--- a/molecule.yml
+++ b/molecule.yml
@@ -13,6 +13,8 @@ vagrant:
       box: ubuntu/xenial64
     - name: jessie64
       box: debian/jessie64
+    - name: stretch64
+      box: debian/stretch64
   providers:
     - name: virtualbox
       type: virtualbox


### PR DESCRIPTION
Debian stretch has been released as 'stable'.
Pick the Ubuntu xenial package from the PPA.